### PR TITLE
Adds configurable trigger modes

### DIFF
--- a/src/button/interrupt.rs
+++ b/src/button/interrupt.rs
@@ -1,5 +1,7 @@
 //! Provides interrupt features for `UserButton` on PA0 for the board
 use cortex_m::peripheral::NVIC;
+use stm32f3xx_hal::stm32::exti::{FTSR1, IMR1, RTSR1};
+use stm32f3xx_hal::stm32::syscfg::EXTICR1;
 use stm32f3xx_hal::stm32::{Interrupt, EXTI, SYSCFG};
 
 /// Used to clear the external interrupt pending register for the user button without moving the EXTI peripheral into global static state.
@@ -22,33 +24,57 @@ pub fn clear() {
     }
 }
 
-/// Configures and enables rising edge interrupt for the `UserButton` on PA0.
+pub enum TriggerMode {
+    Rising,
+    Falling,
+    Both,
+}
+
+/// Configures and enables interrupt for the `UserButton` on PA0.
 ///
 /// # Example
 ///
 /// ```
 /// let device_periphs = stm32::Peripherals::take().unwrap();
-/// button::interrupt::enable(&device_periphs.EXTI, &device_periphs.SYSCFG);
+/// button::interrupt::enable(&device_periphs.EXTI, &device_periphs.SYSCFG, TriggerMode::Rising);
 /// ```
-pub fn enable(external_interrupts: &EXTI, sysconfig: &SYSCFG) {
+pub fn enable(external_interrupts: &EXTI, sysconfig: &SYSCFG, mode: TriggerMode) {
     // See chapter 14 of the reference manual
     // https://www.st.com/content/ccc/resource/technical/document/reference_manual/4a/19/6e/18/9d/92/43/32/DM00043574.pdf/files/DM00043574.pdf/jcr:content/translations/en.DM00043574.pdf
 
-    // enable exti0
-    let interrupt_mask = &external_interrupts.imr1;
-    interrupt_mask.modify(|_, w| w.mr0().set_bit());
+    configure_exti0(&external_interrupts.imr1);
+    map_exti0_to_pa0(&sysconfig.exticr1);
 
-    //TODO: take enum to specify trigger mode {rising, falling, both}
-    // trigger on rising edge
-    let rising_trigger_select = &external_interrupts.rtsr1;
-    rising_trigger_select.modify(|_, w| w.tr0().set_bit());
+    match mode {
+        TriggerMode::Rising => configure_rising_edge_trigger(&external_interrupts.rtsr1),
+        TriggerMode::Falling => configure_falling_edge_trigger(&external_interrupts.ftsr1),
+        TriggerMode::Both => {
+            configure_rising_edge_trigger(&external_interrupts.rtsr1);
+            configure_falling_edge_trigger(&external_interrupts.ftsr1);
+        }
+    }
 
-    // map line EXTI0 to PA0
-    let external_interrupt_config = &sysconfig.exticr1;
+    enable_exti0();
+}
+
+fn configure_exti0(interrupt_mask: &IMR1) {
+    interrupt_mask.modify(|_, w| w.mr0().set_bit())
+}
+
+fn map_exti0_to_pa0(external_interrupt_config: &EXTICR1) {
     const PORT_A_CONFIG: u8 = 0x000;
     external_interrupt_config.modify(|_, w| unsafe { w.exti0().bits(PORT_A_CONFIG) });
+}
 
-    //enable interrupts on EXTI0
+fn configure_rising_edge_trigger(rising_trigger_select: &RTSR1) {
+    rising_trigger_select.modify(|_, w| w.tr0().set_bit())
+}
+
+fn configure_falling_edge_trigger(falling_trigger_select: &FTSR1) {
+    falling_trigger_select.modify(|_, w| w.tr0().set_bit())
+}
+
+fn enable_exti0() {
     unsafe {
         NVIC::unmask(Interrupt::EXTI0);
     }


### PR DESCRIPTION
Closes #12.
This is a breaking change that requires a minor version bump, so we should remove the deprecated struct/method from `Leds` prior to release.