### PR TITLE
Update stm32f3xx-hal 0.5.0 -> 0.6.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ accelerometer = "0.12.0"
 # For the stm32f303vc mcu
 [dependencies.stm32f3xx-hal]
 features = ["stm32f303xc", "rt"]
-version = "0.5.0"
+version = "0.6.1"
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/src/compass.rs
+++ b/src/compass.rs
@@ -36,7 +36,7 @@ impl Compass {
          */
         let scl = pb6.into_af4(mode, alternate_function_low);
         let sda = pb7.into_af4(mode, alternate_function_low);
-        let i2c = i2c::I2c::i2c1(i2c1, (scl, sda), 400.khz(), clocks, advanced_periph_bus);
+        let i2c = i2c::I2c::new(i2c1, (scl, sda), 400.khz(), clocks, advanced_periph_bus);
 
         let lsm303dhlc = Lsm303::new(i2c)?;
         Ok(Compass {


### PR DESCRIPTION
I would like to use SPI in 16-bit mode, which is only supported since `stm32f3xx-hal>=0.6.0`.
In https://github.com/stm32-rs/stm32f3xx-hal/pull/164 the way `Spi` is initialized changed, I adapted the `Compass` code accordingly.

I tested the `compass` example on hardware and it still works, please tell me if I should run any other tests.