### PR TITLE
Add access to LEDs via compass directions

### DIFF
--- a/examples/roulette.rs
+++ b/examples/roulette.rs
@@ -9,8 +9,31 @@ use stm32f3_discovery::stm32f3xx_hal::delay::Delay;
 use stm32f3_discovery::stm32f3xx_hal::prelude::*;
 use stm32f3_discovery::stm32f3xx_hal::pac;
 
-use stm32f3_discovery::leds::Leds;
+use stm32f3_discovery::leds::{Direction, Leds};
 use stm32f3_discovery::switch_hal::OutputSwitch;
+
+fn one_round_by_direction(leds: &mut Leds, delay: &mut Delay) {
+    let slow_delay = 500u16;
+    let directions = [
+        Direction::North,
+        Direction::NorthEast,
+        Direction::East,
+        Direction::SouthEast,
+        Direction::South,
+        Direction::SouthWest,
+        Direction::West,
+        Direction::NorthWest
+    ];
+
+    for direction in &directions {
+        let led = &mut leds.for_direction(*direction);
+
+        led.on().ok();
+        delay.delay_ms(slow_delay);
+        led.off().ok();
+        delay.delay_ms(slow_delay);
+    }
+}
 
 #[entry]
 fn main() -> ! {
@@ -24,7 +47,7 @@ fn main() -> ! {
 
     // initialize user leds
     let mut gpioe = device_periphs.GPIOE.split(&mut reset_and_clock_control.ahb);
-    let leds = Leds::new(
+    let mut leds = Leds::new(
         gpioe.pe8,
         gpioe.pe9,
         gpioe.pe10,
@@ -37,6 +60,10 @@ fn main() -> ! {
         &mut gpioe.otyper,
     );
 
+    // Light them one round by direction.
+    one_round_by_direction(&mut leds, &mut delay);
+
+    // Finally let go by the compass array.
     let mut compass = leds.into_array();
 
     loop {

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -4,6 +4,20 @@ use stm32f3xx_hal::gpio::{Output, PushPull};
 
 use switch_hal::{ActiveHigh, IntoSwitch, OutputSwitch, Switch};
 
+/// LED compass direction as noted on the board
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub enum Direction
+{
+    North,
+    NorthEast,
+    East,
+    SouthEast,
+    South,
+    SouthWest,
+    West,
+    NorthWest,
+}
+
 pub struct Leds {
     /// North
     pub ld3: Switch<gpioe::PEx<Output<PushPull>>, ActiveHigh>,
@@ -83,6 +97,20 @@ impl Leds {
         leds.ld10.off().ok();
 
         leds
+    }
+
+    /// Mutably borrow a LED by the given direction (as noted on the board)
+    pub fn for_direction(&mut self, direction: Direction) -> &mut Switch<gpioe::PEx<Output<PushPull>>, ActiveHigh> {
+        match direction {
+            Direction::North => &mut self.ld3,
+            Direction::NorthEast => &mut self.ld5,
+            Direction::East => &mut self.ld7,
+            Direction::SouthEast => &mut self.ld9,
+            Direction::South => &mut self.ld10,
+            Direction::SouthWest => &mut self.ld8,
+            Direction::West => &mut self.ld6,
+            Direction::NorthWest => &mut self.ld4,
+        }
     }
 
     /// Consumes the `Leds` struct and returns an array


### PR DESCRIPTION
This provides mutable borrows of individual LEDs from `Leds` by a compass direction for #9. Using this feature demonstrated in `examples/roulette.rs` as an extra initial slow round.