### PR TITLE
Bump HAL to get MonoTimer back

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -4,6 +4,7 @@
 # runner = "arm-none-eabi-gdb -q -x openocd.gdb"
 # runner = "gdb-multiarch -q -x openocd.gdb"
 # runner = "gdb -q -x openocd.gdb"
+# runner = "probe-run --chip STM32F303VCTx --connect-under-reset"
 
 rustflags = [
   # LLD (shipped with the Rust toolchain) is used as the default linker

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ accelerometer = "0.12.0"
 # For the stm32f303vc mcu
 [dependencies.stm32f3xx-hal]
 features = ["stm32f303xc", "rt"]
-version = "0.7.0"
+version = "0.8.0"
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ dual licensed as above, without any additional terms or conditions.
 
 ## Changelog
 
+### Unreleased
+
+- Bump HAL to 0.8.0 for getting back [`MonoTimer`](https://docs.rs/stm32f3xx-hal/0.8.0/stm32f3xx_hal/timer/struct.MonoTimer.html) which was accidentially droped with release 0.6.1 and came back with the latest release.
+
 ### 0.7.2
 
 Implements the [Accelerometer trait](https://docs.rs/accelerometer/latest/accelerometer/trait.Accelerometer.html) from the [Accelerometer crate](https://crates.io/crates/accelerometer).

--- a/examples/blinky_int.rs
+++ b/examples/blinky_int.rs
@@ -27,7 +27,7 @@ static TIM: Mutex<RefCell<Option<Timer<pac::TIM7>>>> = Mutex::new(RefCell::new(N
 fn TIM7() {
     free(|cs| {
         if let Some(ref mut tim7) = TIM.borrow(cs).borrow_mut().deref_mut() {
-            tim7.clear_update_interrupt_flag()
+            tim7.clear_event(Event::Update);
         }
     });
 }
@@ -39,8 +39,9 @@ fn main() -> ! {
     let mut rcc = peripherals.RCC.constrain();
 
     let clocks = rcc.cfgr.freeze(&mut flash.acr);
-    let mut timer = Timer::tim7(peripherals.TIM7, 2.Hz(), clocks, &mut rcc.apb1);
-    timer.listen(Event::Update);
+    let mut timer = Timer::new(peripherals.TIM7, clocks, &mut rcc.apb1);
+    timer.start(500u32.milliseconds());
+    timer.enable_interrupt(Event::Update);
     free(|cs| {
         TIM.borrow(cs).replace(Some(timer));
     });


### PR DESCRIPTION
This struct was accidentially dropped and got re-added with the latest release. See https://github.com/stm32-rs/stm32f3xx-hal/pull/247 for details. The breaking changes in `stm32f3xx-hal` 0.8.0 require a small adaption at the examples.

I'm including a runner template for `probe-run` because I'm struggling with https://github.com/rust-lang/vscode-rust/issues/729 and did not manage to get around it with the default Rust extension (only with rust-analyzer).