### PR TITLE
Simplify Button interrupt logic.

### DIFF
--- a/examples/button_int.rs
+++ b/examples/button_int.rs
@@ -6,8 +6,8 @@ extern crate panic_itm;
 use cortex_m_rt::entry;
 
 use stm32f3_discovery::stm32f3xx_hal::interrupt;
-use stm32f3_discovery::stm32f3xx_hal::prelude::*;
 use stm32f3_discovery::stm32f3xx_hal::pac;
+use stm32f3_discovery::stm32f3xx_hal::prelude::*;
 use stm32f3_discovery::wait_for_interrupt;
 
 use core::sync::atomic::{AtomicBool, Ordering};
@@ -31,6 +31,7 @@ fn EXTI0() {
 fn main() -> ! {
     let device_periphs = pac::Peripherals::take().unwrap();
     let mut reset_and_clock_control = device_periphs.RCC.constrain();
+    let syscfg = device_periphs.SYSCFG.constrain(&mut reset_and_clock_control.apb2);
 
     // initialize user leds
     let mut gpioe = device_periphs.GPIOE.split(&mut reset_and_clock_control.ahb);
@@ -48,11 +49,7 @@ fn main() -> ! {
     );
     let mut status_led = leds.ld3;
 
-    button::interrupt::enable(
-        &device_periphs.EXTI,
-        &device_periphs.SYSCFG,
-        TriggerMode::Rising,
-    );
+    button::interrupt::enable(&device_periphs.EXTI, &syscfg, TriggerMode::Rising);
 
     loop {
         // check to see if flag was active and clear it

--- a/src/button/interrupt.rs
+++ b/src/button/interrupt.rs
@@ -37,7 +37,10 @@ pub enum TriggerMode {
 ///
 /// ```
 /// let device_periphs = pac::Peripherals::take().unwrap();
-/// button::interrupt::enable(&device_periphs.EXTI, &device_periphs.SYSCFG, TriggerMode::Rising);
+/// let mut reset_and_clock_control = device_periphs.RCC.constrain();
+/// let syscfg = device_periphs.SYSCFG.constrain(&mut reset_and_clock_control.apb2)
+///
+/// button::interrupt::enable(&device_periphs.EXTI, &syscfg, TriggerMode::Rising);
 /// ```
 pub fn enable(external_interrupts: &EXTI, sysconfig: &SYSCFG, mode: TriggerMode) {
     // See chapter 14 of the reference manual
@@ -59,20 +62,19 @@ pub fn enable(external_interrupts: &EXTI, sysconfig: &SYSCFG, mode: TriggerMode)
 }
 
 fn configure_exti0(interrupt_mask: &IMR1) {
-    interrupt_mask.modify(|_, w| w.mr0().set_bit())
+    interrupt_mask.modify(|_, w| w.mr0().unmasked())
 }
 
 fn map_exti0_to_pa0(external_interrupt_config: &EXTICR1) {
-    const PORT_A_CONFIG: u8 = 0x000;
-    external_interrupt_config.modify(|_, w| unsafe { w.exti0().bits(PORT_A_CONFIG) });
+    external_interrupt_config.modify(|_, w| w.exti0().pa0());
 }
 
 fn configure_rising_edge_trigger(rising_trigger_select: &RTSR1) {
-    rising_trigger_select.modify(|_, w| w.tr0().set_bit())
+    rising_trigger_select.modify(|_, w| w.tr0().enabled())
 }
 
 fn configure_falling_edge_trigger(falling_trigger_select: &FTSR1) {
-    falling_trigger_select.modify(|_, w| w.tr0().set_bit())
+    falling_trigger_select.modify(|_, w| w.tr0().enabled())
 }
 
 fn enable_exti0() {


### PR DESCRIPTION
I was looking to learn how to use my STM32F3Discovery board by looking over the stm32f3-discovery implementation and attempted to implement my own button interrupt (on PB1 using EXTI1). I encountered some difficulty because:

- EXTICR1 changes did not seem to take effect (always 0) and eventually it turned out that SYSCFGEN has to be set before changes take effect. Examples in the repo work because PA is the default in that registry (due to 0-initialization)
- I found the usage of set_bit() and unsafe bits() calls a bit harder to adapt, so I updated the code to use unmasked/pa0/enable

I am learning this stuff, so feedback would be highly appreciated. Thank you!

Actual changes from the log:

1. SYSCFG needs to be constrained. The reason is that constrain looks
like

```
 fn constrain(self, apb2: &mut APB2) -> SysCfg {
        apb2.enr().modify(|_, w| w.syscfgen().enabled());
        ///....
```

which enables the SYSCFG. Without it, SYSCFG.exticr1 changes will not
take effect (everything will still be 0s), which is not noticeable for
the user button because it just happesn that PA0 config is the default,
however for generic code consistency it seems we want to set a usable
example

2. Try to use the seemingly clearer/safer alternatives when setting
IMR1/RTSR1/FTSR1/EXTICR1:

- use `enable` and `unmasked` instead of `set_bit`
- use `pa0()` instead of a custom value write, which also removes
  the need for an unsafe block.