### PR TITLE
Update HAL and cortex-m dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/crate/stm32f3-discovery"
 categories = ["embedded", "hardware-support", "no-std"]
 keywords = ["discovery", "stm32f3", "bsp", "arm"]
 license = "MIT OR Apache-2.0"
-version = "0.7.2"
+version = "0.8.0-pre.0"
 exclude = [
     ".vscode/*",
 ]
@@ -22,8 +22,8 @@ default-target = "thumbv7em-none-eabihf"
 targets = [] # build only default target for docs
 
 [dependencies]
-cortex-m = "0.7.2"
-cortex-m-rt = "0.6.14"
+cortex-m = "0.7"
+cortex-m-rt = "0.7"
 switch-hal = "0.4.0"
 # switch-hal = { git = "https://github.com/rubberduck203/switch-hal", branch = "master" }
 lsm303dlhc = "0.2.0"
@@ -32,7 +32,7 @@ accelerometer = "0.12.0"
 # For the stm32f303vc mcu
 [dependencies.stm32f3xx-hal]
 features = ["stm32f303xc", "rt"]
-version = "0.8.0"
+version = "0.9"
 
 [dev-dependencies]
 panic-halt = "0.2.0"

--- a/examples/accel_pwm.rs
+++ b/examples/accel_pwm.rs
@@ -35,9 +35,9 @@ fn main() -> ! {
     // Prep the pins we need in their correct alternate function
     let mut gpioe = device_periphs.GPIOE.split(&mut reset_and_clock_control.ahb);
 
-    let led_blue = gpioe.pe8.into_af2_push_pull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
-    let led_green = gpioe.pe11.into_af2_push_pull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
-    let lef_red = gpioe.pe13.into_af2_push_pull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
+    let led_blue = gpioe.pe8.into_af_push_pull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
+    let led_green = gpioe.pe11.into_af_push_pull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
+    let lef_red = gpioe.pe13.into_af_push_pull(&mut gpioe.moder, &mut gpioe.otyper, &mut gpioe.afrh);
 
     let max_duty = 4096;
 

--- a/src/compass.rs
+++ b/src/compass.rs
@@ -36,8 +36,8 @@ impl Compass {
          * PE5 -> INT2 (configurable interrupt 2)
          * lsm303hdlc driver uses continuos mode, so no need to wait for interrupts on DRDY
          */
-        let scl = pb6.into_af4_open_drain(mode, otype, alternate_function_low);
-        let sda = pb7.into_af4_open_drain(mode, otype, alternate_function_low);
+        let scl = pb6.into_af_open_drain(mode, otype, alternate_function_low);
+        let sda = pb7.into_af_open_drain(mode, otype, alternate_function_low);
         let i2c = i2c::I2c::new(i2c1, (scl, sda), 400_000.Hz(), clocks, advanced_periph_bus);
 
         let lsm303dhlc = Lsm303::new(i2c)?;


### PR DESCRIPTION
Hello,

Thanks for providing this board crate, it was very useful to quickly get started with OpenOCD and VS Code on my STM32F3-Disco :+1: 
There are newer versions available for some of your dependencies. I updated them and tested this on my STM32F3-Disco. The only thing I tweaked (which was not a breaking change) was replacing a deprecated API, using `into_af_open_drain` instead of `into_af4_...`.

Bumping the dependencies like this probably requires a minor version update, so I did that as well..

Kind Regards
Robin