### PR TITLE
VS Code file updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target/
 !.vscode/launch.json
 !.vscode/tasks.json
 !.vscode/extensions.json
+!.vscode/openocd-helpers.tcl
 
 #temporary files
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,7 @@
             "servertype": "openocd",
             "cwd": "${workspaceRoot}",
             "preLaunchTask": "cargo build --examples",
-            "runToMain": true,
+            "runToEntryPoint": "true",
             "executable": "./target/thumbv7em-none-eabihf/debug/examples/${fileBasenameNoExtension}",
             "preLaunchCommands": ["break rust_begin_unwind"],
             "device": "STM32F303VCT6",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,8 @@
             "preLaunchCommands": ["break rust_begin_unwind"],
             "device": "STM32F303VCT6",
             "configFiles": [
-                "interface/stlink-v2-1.cfg",
+                "${workspaceRoot}/.vscode/openocd-helpers.tcl",
+                "interface/stlink.cfg",
                 "target/stm32f3x.cfg"
             ],
             "svdFile": "${env:HOME}/.svd/STM32F303.svd",

--- a/.vscode/openocd-helpers.tcl
+++ b/.vscode/openocd-helpers.tcl
@@ -1,0 +1,17 @@
+#
+# Cortex-Debug extension calls this function during initialization. You can copy this
+# file, modify it and specifyy it as one of the config files supplied in launch.json
+# preferably at the beginning.
+#
+# Note that this file simply defines a function for use later when it is time to configure
+# for SWO.
+#
+set USE_SWO 0
+proc CDSWOConfigure { CDCPUFreqHz CDSWOFreqHz CDSWOOutput } {
+    # Alternative option: Pipe ITM output into itm.txt file
+    # tpiu config internal itm.txt uart off $CDCPUFreqHz
+
+    # Default option so SWO display of VS code works.
+    tpiu config internal $CDSWOOutput uart off $CDCPUFreqHz $CDSWOFreqHz
+    itm port 0 on
+}


### PR DESCRIPTION
Some tweaks I needed for the SWO viewer in VS code to work.

Some things in the `cortex-debug` plugin changed and it is now possible to write a custom TCL script for the OpenOCD setup.
A [default setup file](https://github.com/Marus/cortex-debug/blob/master/support/openocd-helpers.tcl) is provided, but did not really do the correct thing for me for the SWO viewer to work.

I created a custom version of this script and with that, I was able to use the SWO viewer. It essential does the same thing which is done in the `openocd.gdb` file.

I also replaced the deprecated `"runToMain"` with `"runToEntryPoint"`.