### PR TITLE
disable too many arguments lint for clippy

### DIFF
--- a/src/compass.rs
+++ b/src/compass.rs
@@ -17,6 +17,7 @@ pub struct Compass {
 
 impl Compass {
     /// Initialize the onboard Lsm303dhlc e-Compass
+    #[allow(clippy::too_many_arguments)]
     pub fn new<Pb6Mode, Pb7Mode>(
         pb6: gpiob::PB6<Pb6Mode>,
         pb7: gpiob::PB7<Pb7Mode>,

--- a/src/leds.rs
+++ b/src/leds.rs
@@ -63,6 +63,7 @@ pub struct Leds {
 
 impl Leds {
     /// Initializes the user LEDs to OFF
+    #[allow(clippy::too_many_arguments)]
     pub fn new<PE8Mode, PE9Mode, PE10Mode, PE11Mode, PE12Mode, PE13Mode, PE14Mode, PE15Mode>(
         pe8: gpioe::PE8<PE8Mode>,
         pe9: gpioe::PE9<PE9Mode>,


### PR DESCRIPTION
for Compass::new and Leds::new .